### PR TITLE
TOXVAL-452

### DIFF
--- a/R/deprecated/toxval.load.wignall_20230602.R
+++ b/R/deprecated/toxval.load.wignall_20230602.R
@@ -4,7 +4,6 @@
 #' @param toxval.db The version of toxval into which the tables are loaded.
 #' @param source.db The version of toxval_source from which the tables are loaded.
 #' @param log If TRUE, send output to a log file
-#' @export
 #--------------------------------------------------------------------------------------
 toxval.load.wignall <- function(toxval.db,source.db, log=F){
   printCurrentFunction(toxval.db)

--- a/R/toxval.load.all.R
+++ b/R/toxval.load.all.R
@@ -76,7 +76,7 @@ toxval.load.all <- function(toxval.db,
       toxval.load.pprtv.cphea(toxval.db,source.db,log)
       toxval.load.rsl(toxval.db,source.db,log)
       toxval.load.ut_hb(toxval.db,source.db,log)
-      toxval.load.wignall(toxval.db,source.db,log)
+      #toxval.load.wignall(toxval.db,source.db,log)
       toxval.load.test(toxval.db,source.db,log)
       toxval.load.chemidplus(toxval.db,source.db,log)
       toxval.load.toxrefdb2.1(toxval.db,source.db,log)


### PR DESCRIPTION
deprecated toxval.load.wignall.R- added date stem to file name, removed export tag, and moved to deprecated folder. Commented out toxval.load.wignall in toxval.load.all.R function