### PR TITLE
TOXVAL-453

### DIFF
--- a/R/deprecated/toxval.load.efsa2_20230602.R
+++ b/R/deprecated/toxval.load.efsa2_20230602.R
@@ -3,7 +3,6 @@
 #' @param toxval.db The version of toxval into which the tables are loaded.
 #' @param source.db The source databse from which data should be loaded
 #' @param log If TRUE, send output to a log file
-#' @export
 #--------------------------------------------------------------------------------------
 toxval.load.efsa2 <- function(toxval.db,source.db, log=F) {
   printCurrentFunction(toxval.db)

--- a/R/toxval.load.all.R
+++ b/R/toxval.load.all.R
@@ -56,7 +56,7 @@ toxval.load.all <- function(toxval.db,
       toxval.load.doe.benchmarks(toxval.db,source.db,log)
       toxval.load.doe.ecorisk(toxval.db,source.db,log)
       toxval.load.doe.pac(toxval.db,source.db,log)
-      toxval.load.efsa2(toxval.db,source.db,log)
+      #toxval.load.efsa2(toxval.db,source.db,log)
       toxval.load.efsa(toxval.db,source.db,log)
       toxval.load.envirotox(toxval.db,source.db,log)
       toxval.load.hawc_pfas_150(toxval.db,source.db,log)


### PR DESCRIPTION
moved toxval.load.efsa2.R to a deprecated folder, added date stem to its filename, removed export tag. Commented out toxval.load.efsa2 from toxval.load.all.R