### PR TITLE
TOXVAL-539

### DIFF
--- a/R/toxval.load.ntp.pfas.R
+++ b/R/toxval.load.ntp.pfas.R
@@ -42,7 +42,8 @@ toxval.load.generic <- function(toxval.db, source.db, log=FALSE, remove_null_dtx
                    "WHERE chemical_id IN (SELECT chemical_id FROM source_chemical WHERE dtxsid is NOT NULL)")
   }
   res = runQuery(query,source.db,TRUE,FALSE)
-  res = res[,!names(res) %in% toxval.config()$non_hash_cols[!toxval.config()$non_hash_cols %in% c("chemical_id")]]
+  res = res[,!names(res) %in% toxval.config()$non_hash_cols[!toxval.config()$non_hash_cols %in%
+                                                              c("chemical_id", "document_name", "source_hash", "qc_status")]]
   res$source = source
   res$details_text = paste(source,"Details")
   print(paste0("Dimensions of source data: ", toString(dim(res))))
@@ -51,13 +52,8 @@ toxval.load.generic <- function(toxval.db, source.db, log=FALSE, remove_null_dtx
   cat("Add code to deal with specific issues for this source\n")
   #####################################################################
   res = res %>%
-    # Add columns as needed
-    dplyr::mutate(
-      source_url = url
-    ) %>%
-
-    # Filter out duplicate rows
-    dplyr::distinct()
+    # Add source_url column for record source table
+    dplyr::mutate(source_url = url)
 
   #####################################################################
   cat("find columns in res that do not map to toxval or record_source\n")
@@ -72,7 +68,7 @@ toxval.load.generic <- function(toxval.db, source.db, log=FALSE, remove_null_dtx
   nlist = nlist[!is.element(nlist,cols)]
 
   # Remove unnecessary columns ("columns to be dealt with)
-  res = res %>% dplyr::select(!nlist)
+  res = res %>% dplyr::select(!dplyr::any_of(nlist))
 
   nlist = names(res)
   nlist = nlist[!is.element(nlist,c("casrn","name"))]


### PR DESCRIPTION
Initial draft of NTP PFAS load script.

I added NTP PFAS to an updated source_info document, which can be found at: "/ccte/ACToR1/ToxValDB9/Repo/dictionary/source_info 2023-11-30.xlsx". The load script reads from this file instead of the previous source_info document.

Because the DTSXID column is not yet available in the source data, I set do.convert.units in toxval,load.postprocess.R to FALSE while running and testing the script to avoid errors.