### PR TITLE
TOXVAL-540

### DIFF
--- a/R/toxval.load.hawc.R
+++ b/R/toxval.load.hawc.R
@@ -55,7 +55,7 @@ toxval.load.hawc <- function(toxval.db, source.db, log=FALSE, remove_null_dtxsid
             "endpoint_url_original","study_id","authors_short","full_text_url","study_url_original",
             "experiment_name","experiment_type","chemical_source","guideline_compliance","dosing_regime_id",
             "route_of_exposure","exposure_duration_value","exposure_duration_text","doses","endpoint_url",
-            "study_url")
+            "study_url", "study_duration_qualifier")
   res = res[ , !(names(res) %in% cremove)]
 
   #####################################################################


### PR DESCRIPTION
Updated script to better resemble the generic script. Removed the old code that was not necessary. Many of the transformations for exposure and study duration parameters were still necessary, as these fields weren't toxval ready in toxval_source.