### PR TITLE
Update fix.qc_status.by.source.R

### DIFF
--- a/R/fix.qc_status.by.source.R
+++ b/R/fix.qc_status.by.source.R
@@ -67,7 +67,7 @@ fix.qc_status.by.source <- function(toxval.db, source.db, source=NULL, subsource
                     "WHEN qc_status like '%fail%' THEN CONCAT(qc_status, '; toxval_numeric<0') ",
                     "ELSE 'fail:toxval_numeric<0'",
                     "END ",
-                    "WHERE toxval_numeric<=0 and source = '",source,"'",query_addition) ,toxval.db)
+                    "WHERE toxval_numeric<=0 AND study_type NOT IN ('Toxicity Value', 'Media Exposure Guidelines', 'Acute Exposure Guidelines') AND source = '",source,"'",query_addition) ,toxval.db)
 
     runQuery(paste0("UPDATE toxval SET  qc_status = CASE ",
                     "WHEN qc_status like '%toxval_numeric is null%' THEN qc_status ",


### PR DESCRIPTION
Values of zero were only supposed to be dropped for experimental records/dose response summary values. UPDATE statement to set qc_status to 'fail' where toxval_numeric<=0 was edited to reflect the correct logic. This will prevent the error from happening to new records in the future, but does not add the missed MCLG=0 records back to the database. I don't believe logic is in place for a case where a record is failed errantly, so I believe this source will have to be reloaded at the least.